### PR TITLE
GH action to update submodule

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,0 +1,47 @@
+name: Update submodule pointer
+
+on:
+  repository_dispatch:
+    types: [submodule-updated]
+  workflow_dispatch:
+
+concurrency:
+  group: update-submodule
+  cancel-in-progress: true
+
+jobs:
+  update-submodule:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+          submodules: true
+          # Use default GITHUB_TOKEN — has push access to the repo
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update submodule to latest dev
+        run: |
+          cd plugins/temporal-developer/skills/temporal-developer
+          git fetch origin dev
+          git checkout origin/dev
+          cd "$GITHUB_WORKSPACE"
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add plugins/temporal-developer/skills/temporal-developer
+          git commit -m "update submodule to latest dev"
+          git push origin dev


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Adds a GH action which bumps the skill submodule pointer to the latest SHA, and pushes a commit doing so. This **only** changes the `dev` branch of `agent-skills`, and **only** uses SHAs from the `dev` branch of `skill-temporal-developer`.

## Why?
It is quite annoying to manually make submodule updating commits, and at least for the `dev` branches we do always want them to be in sync.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Will have to test after merging.

3. Any docs updates needed?
No
