### PR TITLE
Add initial Java sdk version

### DIFF
--- a/.memory/sdk-versions.json
+++ b/.memory/sdk-versions.json
@@ -12,6 +12,10 @@
     "go": {
       "repo": "temporalio/sdk-go",
       "version": "1.40.0"
+    },
+    "java": {
+      "repo": "temporalio/sdk-java",
+      "version": "1.33.0"
     }
   }
 }


### PR DESCRIPTION
Simply tracks the initial version of the Java SDK that the skill was based on.