### PR TITLE
Rename plugin from temporal-developer to temporal

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "temporal-developer",
+  "name": "temporal",
   "version": "0.2.0",
-  "description": "Comprehensive skill for developing Temporal applications across Python, TypeScript, Go, and Java.",
+  "description": "Comprehensive skill for the entire Temporal lifecycle — developing applications, using the Temporal CLI, running and managing Temporal Server, and working with Temporal Cloud.",
   "author": {
     "name": "Temporal",
     "url": "https://temporal.io/"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Temporal Developer Plugin for Claude Code
+# Temporal Plugin for Claude Code
 
-This repository provides a [Claude Code plugin](https://code.claude.com/docs/en/plugins) for developing [Temporal](https://temporal.io/) applications.
+This repository provides a [Claude Code plugin](https://code.claude.com/docs/en/plugins) for working with [Temporal](https://temporal.io/) — developing applications, using the CLI, managing server, and working with Temporal Cloud.
 
 > [!WARNING]
 > This plugin is in Public Preview, and will continue to evolve and improve.
@@ -17,7 +17,7 @@ This repository provides a [Claude Code plugin](https://code.claude.com/docs/en/
 5. Select **Enable auto-update** or **Disable auto-update**
 
 **Step 2:** Plugin Installation
-1. Run `/plugin install temporal-developer@temporal-marketplace`
+1. Run `/plugin install temporal@temporal-marketplace`
 2. Restart Claude Code
 
 ## What's Included


### PR DESCRIPTION
## Summary
- Rename plugin from `temporal-developer` to `temporal`
- Update description to cover the entire Temporal platform lifecycle — CLI, server, and cloud — not just SDK development

## Test plan
- [ ] Verify plugin installs correctly with new name
- [ ] Confirm marketplace listing reflects updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)