### PR TITLE
Simplify README install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,21 @@ This repository provides a [Claude Code plugin](https://code.claude.com/docs/en/
 
 ## Installation
 
-**Step 1:** Marketplace Installation
+From inside Claude Code, run:
 
-1. Run `/plugin marketplace add temporalio/claude-temporal-plugin`
-2. Run `/plugin` to open the plugin manager
-3. Select **Marketplaces**
-4. Choose `temporal-marketplace` from the list
-5. Select **Enable auto-update** or **Disable auto-update**
+1. `/plugin marketplace add temporalio/claude-temporal-plugin`
+2. `/plugin install temporal@temporal-marketplace`
 
-**Step 2:** Plugin Installation
-1. Run `/plugin install temporal@temporal-marketplace`
-2. Restart Claude Code
+Then run `/reload-plugins` to activate the plugin in the current session.
+
+### Alternative: interactive install
+
+1. Run `/plugin` to open the plugin manager
+2. Select **Marketplaces**
+3. Choose `temporal-marketplace` from the list
+4. Select **Enable auto-update** or **Disable auto-update**
+5. Install the `temporal` plugin
+6. Run `/reload-plugins`
 
 ## What's Included
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ From inside Claude Code, run:
 
 Then run `/reload-plugins` to activate the plugin in the current session.
 
+*Note:* We recommend enabling automatic updates using the interactive `/plugin` menu 
+
 ### Alternative: interactive install
 
 1. Run `/plugin` to open the plugin manager
 2. Select **Marketplaces**
 3. Choose `temporal-marketplace` from the list
-4. Select **Enable auto-update** or **Disable auto-update**
+4. Select **Enable auto-update** (recommended) or **Disable auto-update**
 5. Install the `temporal` plugin
 6. Run `/reload-plugins`
 


### PR DESCRIPTION
## Summary
- Lead with the two slash commands (`/plugin marketplace add` + `/plugin install`) as the primary install path
- Move the plugin-manager walkthrough to a secondary "Alternative: interactive install" section
- Replace "Restart Claude Code" with `/reload-plugins`, which activates the plugin in the current session without a restart

## Test plan
- [ ] Render the README on GitHub and verify the Installation section reads cleanly
- [ ] Follow the two-command flow end-to-end in Claude Code and confirm the `temporal` plugin loads after `/reload-plugins`
- [ ] Follow the alternative interactive flow and confirm it also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)