### PR TITLE
Add release workflow to bump Claude plugin version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Bump plugin version
         id: bump
+        env:
+          BUMP: ${{ inputs.bump }}
         run: |
           set -euo pipefail
           PLUGIN_FILE=".claude-plugin/plugin.json"
@@ -39,7 +41,7 @@ jobs:
 
           IFS='.' read -r MAJOR MINOR PATCH <<< "$OLD_VERSION"
 
-          case "${{ inputs.bump }}" in
+          case "$BUMP" in
             major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
             minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
             patch) PATCH=$((PATCH + 1)) ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release Claude Plugin
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
+
+      - name: Bump plugin version
+        id: bump
+        run: |
+          set -euo pipefail
+          PLUGIN_FILE=".claude-plugin/plugin.json"
+
+          OLD_VERSION=$(jq -r '.version' "$PLUGIN_FILE")
+          if [ -z "$OLD_VERSION" ] || [ "$OLD_VERSION" = "null" ]; then
+            echo "Could not read version from $PLUGIN_FILE" >&2
+            exit 1
+          fi
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$OLD_VERSION"
+
+          case "${{ inputs.bump }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+          tmp=$(mktemp)
+          jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN_FILE" > "$tmp"
+          mv "$tmp" "$PLUGIN_FILE"
+
+          echo "old_version=$OLD_VERSION" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Bumped $OLD_VERSION -> $NEW_VERSION"
+
+      - name: Commit and tag
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          OLD_VERSION: ${{ steps.bump.outputs.old_version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add .claude-plugin/plugin.json
+          git commit -m "Bump version from ${OLD_VERSION} to ${NEW_VERSION}"
+          git tag "v${NEW_VERSION}"
+
+          git push origin HEAD:main
+          git push origin "v${NEW_VERSION}"


### PR DESCRIPTION
## Summary
Adds a manually-dispatched GitHub Actions workflow that releases the Claude plugin by bumping its version number.

## What it does
- Triggered via **workflow_dispatch** with a `bump` input (`patch`/`minor`/`major`, defaults to `patch`).
- Increments the version in `.claude-plugin/plugin.json` using `jq`. Skill versions are intentionally left untouched. (`.claude-plugin/marketplace.json` has no version field, so nothing to change there.)
- Commits the bump directly to `main` as `Bump version from X to Y` and pushes a `v<version>` tag.

## Auth / setup required
Pushes over SSH using a deploy key so it can bypass the `main` ruleset (the built-in `github-actions[bot]` can't be added to a ruleset bypass list). Before first use:
1. Generate a deploy key and add the public key under **Settings → Deploy keys** with **write access**.
2. Add the private key as the `RELEASE_SSH_KEY` repo secret.
3. Add the deploy key to the `main` ruleset's **bypass list**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)